### PR TITLE
Complete the AD transformer class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: Algorithm-Distillation
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    # Skip CI if [ci skip] in the commit message
+    if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.9", "3.10" ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip3 install torch --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install .[test]
+      - name: Lint with flake8
+        run: |
+          make lint
+      - name: Type-check
+        run: |
+          make type
+      - name: Test using pytest
+        run: |
+          make pytest

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.benchmarks
+.pytype

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+SHELL=/bin/bash
+LINT_PATHS=algorithm_distillation/
+
+pytest:
+	python -m pytest tests/
+
+pytype:
+	pytype ${LINT_PATHS}
+
+type: pytype
+
+lint:
+	# stop the build if there are Python syntax errors or undefined names
+	flake8 ${LINT_PATHS} --count --select=E9,F63,F7 --show-source --statistics --max-line-length=88
+	flake8 ${LINT_PATHS} --count --exit-zero --ignore=E203,E501,F811 --show-source --statistics --max-line-length=88
+
+format:
+	# Sort imports
+	isort ${LINT_PATHS}
+	# Reformat using black
+	black -l 88 ${LINT_PATHS}
+
+check-codestyle:
+	# Sort imports
+	isort --check ${LINT_PATHS}
+	# Reformat using black
+	black --check -l 88 ${LINT_PATHS}
+
+commit-checks: format type lint
+
+clean:
+	cd docs && make clean
+
+.PHONY: clean lint format check-codestyle commit-checks

--- a/algorithm_distillation/__init__.py
+++ b/algorithm_distillation/__init__.py
@@ -1,0 +1,5 @@
+from .ad import AlgorithmDistillation, GymAD
+from .task import GymTask, Task
+from .task_manager import TaskManager
+
+__all__ = ["AlgorithmDistillation", "GymAD", "Task", "GymTask", "TaskManager"]

--- a/algorithm_distillation/ad.py
+++ b/algorithm_distillation/ad.py
@@ -1,0 +1,113 @@
+import abc
+
+import torch
+
+from algorithm_distillation.models.ad_transformer import ADTransformer
+
+from .task_manager import TaskManager
+
+
+class AlgorithmDistillation(abc.ABC):
+    """
+    This is the base class of controllers of algorithm distillation training.
+    """
+
+    def __init__(self, model: ADTransformer):
+        self.model = model
+
+    @abc.abstractmethod
+    def train(
+        self,
+        task_manager: TaskManager,
+        steps: int,
+        length: int,
+        skip: int,
+        batch_size: int,
+        **config
+    ):
+        pass
+
+
+class GymAD(AlgorithmDistillation):
+    def train(
+        self,
+        task_manager: TaskManager,
+        steps: int,
+        length: int,
+        skip: int,
+        batch_size: int,
+        **config
+    ):
+        """
+        Collect samples and train `steps` amount of gradient steps.
+
+        :param task_manager: the controller that controls a collection of tasks.
+        :param steps: the amount of gradient steps to train.
+        :param length: the step-length of sampled sequences (not the sequence length which is 3x).
+        :param skip: the amount of states to skip between two consecutive ones.
+        :param batch_size: the batch size.
+        :param config: the extra config that goes into transformer training.
+        :return: None
+        """
+        # We implement a PyTorch training loop.
+        # Use GPU if exists.
+        device = (
+            torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+        )
+        data_iter = self._get_data_iter(
+            steps, batch_size, task_manager, length, skip, device=device
+        )
+        self.model.to(device)
+        optimizer = torch.optim.Adam(self.model.parameters(), lr=1e-2)
+
+        self.model.train()  # Set to train mode so that dropout and batch norm would update.
+        losses = []
+        for step, sample in enumerate(data_iter):
+            optimizer.zero_grad()
+            obs, actions, rewards = sample
+            one_hot_actions = torch.nn.functional.one_hot(
+                actions.squeeze(-1), num_classes=self.model.act_dim
+            ).type(torch.float)
+            loss = self._compute_loss(
+                self.model(obs, one_hot_actions, rewards, action_only=True), actions
+            )
+            loss.backward()
+            losses.append(loss.item())
+            optimizer.step()
+
+        self.model.eval()  # By default, set to eval mode outside of training.
+
+        print(losses)
+
+    @staticmethod
+    def _get_data_iter(
+        steps: int, batch_size, task_manager, length, skip, device=torch.device("cpu")
+    ):
+        for _ in range(steps):
+            samples = []
+            for _ in range(batch_size):
+                samples.append(task_manager.sample_history(length, skip))
+
+            yield (
+                torch.tensor(
+                    [sample[0] for sample in samples], dtype=torch.float, device=device
+                ),  # observations
+                torch.tensor(
+                    [sample[1] for sample in samples], dtype=torch.long, device=device
+                ),  # actions
+                torch.tensor(
+                    [sample[2] for sample in samples], dtype=torch.float, device=device
+                ),  # rewards
+            )
+
+    @staticmethod
+    def _compute_loss(x, y) -> torch.Tensor:
+        """
+        :param x: action logits.
+        :param y: the target action.
+        :return: the NLL loss.
+        """
+        assert y.dtype == torch.long
+        assert x.shape[:-1] + (1,) == y.shape
+        x = torch.nn.functional.log_softmax(x)  # (b, length, action_num)
+        return -torch.take_along_dim(x, y, dim=len(y.shape) - 1).sum(-1).mean()

--- a/algorithm_distillation/models/__init__.py
+++ b/algorithm_distillation/models/__init__.py
@@ -1,0 +1,3 @@
+from .gpt2 import GPT2AD
+
+__all__ = ["util", "GPT2AD"]

--- a/algorithm_distillation/models/ad_transformer.py
+++ b/algorithm_distillation/models/ad_transformer.py
@@ -1,0 +1,27 @@
+import abc
+
+import torch
+
+
+class ADTransformer(abc.ABC, torch.nn.Module):
+    obs_dim: int
+    act_dim: int
+
+    @abc.abstractmethod
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    @abc.abstractmethod
+    def forward(
+        self,
+        obs,
+        actions,
+        rewards,
+        current_obs,
+        current_action=None,
+        current_reward=None,
+        attention_mask=None,
+        step_ids=None,
+        current_step_id=None,
+    ):
+        pass

--- a/algorithm_distillation/models/gpt2.py
+++ b/algorithm_distillation/models/gpt2.py
@@ -1,0 +1,197 @@
+"""
+This implements an AD transformers as the subclass of a GPT-2 model.
+The code is inspired by the implementation of Decision Transformer (DT):
+  https://github.com/kzl/decision-transformer
+"""
+import logging
+from typing import Union
+
+import torch
+import transformers
+
+from .ad_transformer import ADTransformer
+from .util import stack_seq
+
+logger = logging.getLogger(__name__)
+
+
+class ZeroDummy(torch.nn.Module):
+    """
+    Directly output zeros of given shape (replace the last axis of the input tensor).
+    """
+
+    def __init__(self, output_shape: tuple):
+        super(ZeroDummy, self).__init__()
+        self.output_shape = output_shape
+
+    def forward(self, x):
+        shape = x.shape[:-1] + self.output_shape
+        return torch.zeros(shape, dtype=x.dtype, device=x.device)
+
+
+class GPT2AD(ADTransformer):
+    def __init__(
+        self,
+        obs_dim,
+        act_dim,
+        hidden_size,
+        max_ep_len=4096,
+        action_tanh=True,
+        obs_emb_cls=torch.nn.Linear,
+        act_emb_cls=torch.nn.Linear,
+        rew_emb_cls=torch.nn.Linear,
+        **kwargs
+    ):
+        """
+        The AD model with GPT2 as the underlying model.
+
+        :param obs_dim: observation dimension (as a flattened tensor)
+        :param act_dim: action dimension (as a flattened tensor)
+        :param hidden_size: the dimension of the embedding space
+        :param max_ep_len: (Optional) maximal episode length
+        :param action_tanh: (Optional) apply tanh activation function on the action
+        :param obs_emb_cls: (Optional) the nn.Module class for observation embedding
+        :param act_emb_cls: (Optional) the nn.Module class for action embedding
+        :param rew_emb_cls: (Optional) the nn.Module class for reward embedding
+        :param kwargs: (Optional) other param for the underlying GPT2 transformers
+        """
+        super(GPT2AD, self).__init__()
+
+        self.obs_dim = obs_dim
+        self.act_dim = act_dim
+        self.hidden_size = hidden_size
+        self.action_tanh = action_tanh
+        # Generate the most basic GPT2 config
+        config = transformers.GPT2Config(vocab_size=1, n_embd=hidden_size, **kwargs)
+        self.transformers = transformers.GPT2Model(config)
+        # Remove the position embedding by replacing it with a dummy.
+        self.transformers.wpe = ZeroDummy((hidden_size,))
+        # This is our position embedding based on steps.
+        self.step_embedding = torch.nn.Embedding(max_ep_len, self.hidden_size)
+
+        # The embedding layers
+        self.obs_embedding = obs_emb_cls(self.obs_dim, self.hidden_size)
+        self.act_embedding = act_emb_cls(self.act_dim, self.hidden_size)
+        self.rew_embedding = rew_emb_cls(1, self.hidden_size)
+
+        # The last layers mapping to obs/action/reward from the embedding space.
+        self.obs_head = torch.nn.Linear(self.hidden_size, self.obs_dim)
+        # Generate action head. Append a tanh activation if `action_tanh` is True
+        act_head_list = [torch.nn.Linear(self.hidden_size, self.act_dim)]
+        if self.action_tanh:
+            act_head_list.append(torch.nn.Tanh())
+        self.act_head = torch.nn.Sequential(*act_head_list)
+        self.rew_head = torch.nn.Linear(self.hidden_size, 1)
+
+        self.layer_norm_in_embedding = torch.nn.LayerNorm(self.hidden_size)
+
+    def forward(
+        self,
+        obs,
+        actions,
+        rewards,
+        current_obs=None,
+        current_action=None,
+        current_reward=None,
+        attention_mask=None,
+        step_ids=None,
+        current_step_id=None,
+        action_only=False,
+    ) -> Union[torch.Tensor, tuple]:
+        """
+        Input represents a sequence of observations, actions, rewards, they line up as
+        following:
+
+        `obs_1, act_1, rew_1, ..., obs_t, act_t, rew_t, latest_obs, latest_action, latest_reward`
+
+        The parameters `latest_action`, `latest_reward` can be None if they do not apply.
+        The model returns the next action, reward or state. Common usage is to predict
+        the next action, so the result should normally be `next_action`.
+        But other cases are allowed, e.g.,
+        `..., latest_obs, latest_act, None` -> `next_reward`
+
+        :param obs: (b, t, obs_dim)
+        :param actions: (b, t, act_dim)
+        :param rewards: (b, t, 1)
+        :param current_obs: (Optional) (b, obs_dim)
+        :param current_action: (Optional) shape (b, act_dim)
+        :param current_reward: (Optional) shape (b, 1)
+        :param attention_mask: (Optional) shape (b, t)
+        :param step_ids: (Optional) shape (b, t), similar to `position_ids` in GPT2
+        :param current_step_id: (Optional) the latest step id applied to the latest obs/act/rew.
+        :param action_only: (Optional) return predicted actions only.
+        :return: predicted action logits (if action_only) or predicted action logits, rewards, and obs.
+        """
+        device = obs.device
+
+        batch_size, timestep, _ = obs.shape
+        if current_step_id is None:
+            if step_ids is not None:
+                logger.warning(
+                    "'current_step_id' defaults to the number of steps. But it may conflict with the given 'step_ids'."
+                )
+            current_step_id = timestep
+
+        if attention_mask is None:
+            attention_mask = torch.ones(
+                (batch_size, timestep), dtype=torch.float, device=device
+            )
+
+        if step_ids is None:
+            step_ids = torch.arange(0, timestep, dtype=torch.long, device=device).view(
+                1, timestep
+            )
+        embedded_steps = self.step_embedding(step_ids).view(
+            1, timestep, self.hidden_size
+        )
+
+        embedded_obs = self.obs_embedding(obs) + embedded_steps
+        embedded_act = self.act_embedding(actions) + embedded_steps
+        embedded_rew = self.rew_embedding(rewards) + embedded_steps
+        embedded_latest_step = self.step_embedding(
+            torch.tensor([current_step_id], dtype=torch.long, device=device)
+        )
+
+        # Embed the current obs/action/reward (stop if None)
+        latest = [current_obs, current_action, current_reward]
+        apply_cls = [self.obs_embedding, self.act_embedding, self.rew_embedding]
+        extra = []
+        for inp, cls in zip(latest, apply_cls):
+            if inp is not None:
+                extra.append(cls(inp) + embedded_latest_step)  # (b, hidden_size)
+            else:
+                break
+        num_extra = len(extra)  # number of non-empty current obs/action/reward
+        extra = torch.stack(extra, dim=1) if extra else None
+
+        # Stack the input into (obs, act, rew, obs, act, rew, ...) sequence.
+        # Note: only affects axis 1. Axis 0 (batch) and axis 2 (embedding) are preserved.
+        input_seq = stack_seq(embedded_obs, embedded_act, embedded_rew, extra)
+        input_seq = self.layer_norm_in_embedding(input_seq)
+        attention_mask = (
+            attention_mask.unsqueeze(-1).repeat((1, 1, 3)).view(batch_size, -1)
+        )
+        attention_mask = torch.concat(
+            [
+                attention_mask,
+                torch.ones((batch_size, num_extra), dtype=torch.float, device=device),
+            ],
+            dim=1,
+        )
+
+        # Do inference using the underlying transformer.
+        output = self.transformers(
+            inputs_embeds=input_seq, attention_mask=attention_mask
+        )  # (b, *, hidden_size)
+        pred_actions = output["last_hidden_state"][:, ::3, :]
+        pred_rewards = output["last_hidden_state"][:, 1::3, :]
+        pred_obs = output["last_hidden_state"][:, 2::3, :]
+
+        if action_only:
+            return self.act_head(pred_actions)
+        else:
+            return (
+                self.act_head(pred_actions),
+                self.rew_head(pred_rewards),
+                self.obs_head(pred_obs),
+            )

--- a/algorithm_distillation/models/util.py
+++ b/algorithm_distillation/models/util.py
@@ -1,0 +1,19 @@
+import torch
+
+
+def stack_seq(obs, act, rew, extra=None) -> torch.Tensor:
+    """
+    Stack up into a sequence (obs, act, rew, obs, act, rew, ...) in axis 1,
+    and append extra in the end.
+    :param obs: shape (b, t, hidden_size)
+    :param act: shape (b, t, hidden_size)
+    :param rew: shape (b, t, hidden_size)
+    :param extra: (Optional) shape (b, i, hidden_size) where i can be 1, 2 or 3
+    :return: shape (b, 3*t+i, hidden_size)
+    """
+    batch_size, timestep, _ = obs.shape
+    stacked = torch.stack((obs, act, rew), dim=2).view(batch_size, 3 * timestep, -1)
+    if extra is None:
+        return stacked
+    else:
+        return torch.concat([stacked, extra], dim=1)

--- a/algorithm_distillation/task.py
+++ b/algorithm_distillation/task.py
@@ -1,0 +1,240 @@
+import abc
+import math
+import random
+from typing import Optional
+
+import gym
+import numpy as np
+import stable_baselines3
+from stable_baselines3.common.buffers import ReplayBuffer
+
+
+class Task(abc.ABC):
+    """
+    This class controls the training of one single task.
+    Each object controls one single trainable model inside.
+    """
+
+    # `obs_dim` marks the total dimension of the observations
+    obs_dim: int
+
+    @abc.abstractmethod
+    def __init__(self, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def train(self, steps: int):
+        """
+        Train a number of steps.
+
+        :param steps: the number of steps to train
+        :return: None
+        """
+        pass
+
+    @abc.abstractmethod
+    def sample_history(self, length: int, skip: int = 0) -> tuple:
+        """
+        Sample a history of specific length.
+
+        :param length: the length of the history.
+        (note: length of training steps instead of length of sequence! Every step
+        includes obs, act, rew. Thus, the final sequence is 3x as long.)
+        :param skip: (Optional) skip certain amount of steps between two states.
+        :return: a tuple of (observations, actions, rewards). Each is a tensor.
+        """
+        pass
+
+
+class GymTask(Task):
+    # TODO: Still need some work to set up the on-policy algorithms due to problems in their rollout buffers.
+    _algorithms = {"DQN": stable_baselines3.DQN}
+    _on_policy = ("PPO",)
+
+    # If the environment has a discrete obs space of n classes, return an (n,)-shape array for each obs.
+    # If the environment has a continuous obs space of certain shape, return a flattened array for each obs.
+    obs_dim: int
+    obs_cls: str
+
+    def __init__(self, env, algorithm: str, config: Optional[dict] = None):
+        """
+        GymTask takes in a gym environment and set up a stable-baselines3 algorithm to train a policy network.
+
+        :param env: the gym environment
+        :param algorithm: the stable-baselines3 algorithm
+        :param config: (Optional) the stable-baselines3 algorithm config (except for the gym environment)
+        """
+        self.env = env
+        if not isinstance(env.action_space, gym.spaces.Discrete):
+            raise ValueError("Only support discrete action spaces.")
+
+        self.algorithm = algorithm
+        if algorithm not in self._algorithms:
+            raise ValueError(
+                f"Input must be one of {self._algorithms.keys()}. Got {algorithm} instead."
+            )
+
+        self.config = {} if config is None else config.copy()
+        self.config["env"] = self.env
+        # Default to MultiInputPolicy which is applicable most of the time.
+        if "policy" not in self.config:
+            self.config["policy"] = "MultiInputPolicy"
+
+        self.agent = self._algorithms[algorithm](**self.config)
+        self.obs_dim, self.obs_cls = self._get_obs_specs()
+
+    def train(self, steps: int):
+        self.agent.learn(total_timesteps=steps)
+
+    def sample_history(
+        self, length: int, skip: int = 0, most_recent: bool = False
+    ) -> tuple:
+        """
+        This implementation will sample their most recent histories.
+
+        :param length: the length of the history .
+        (note: length of training steps instead of length of sequence! Every step
+        includes obs, act, rew. Thus, the final sequence is 3x as long.)
+        :param skip: (Optional) skip certain amount of steps between two states
+        :param most_recent: (Optional) sample from the most recent histories. False to sample randomly.
+        :return: a tuple of (observations, actions, rewards). Each is a tensor.
+        """
+        if self.algorithm in self._on_policy:
+            raise NotImplementedError("Not supporting on-policy algorithms yet.")
+
+        buffer = self.agent.replay_buffer
+
+        if buffer.n_envs != 1:
+            raise NotImplementedError("Not supporting parallel environments yet.")
+
+        if most_recent:
+            return self._get_most_recent_history(buffer, length, skip)
+        else:
+            return self._randomly_sample_buffer(buffer, length, skip)
+
+    def _get_obs_specs(self) -> tuple:
+        if not hasattr(self, "env"):
+            raise ValueError('Need to assign "env" attribute first.')
+        obs_space = self.env.observation_space
+
+        if isinstance(obs_space, gym.spaces.Discrete):
+            return obs_space.n, "discrete"
+        elif isinstance(obs_space, gym.spaces.Box):
+            return math.prod([n for n in obs_space.shape]), "box"
+        else:
+            raise NotImplementedError(
+                f"The observation space does not support {type(obs_space)}."
+            )
+
+    def _obs_post_process(self, obs: np.ndarray) -> np.ndarray:
+        """
+        Post-process the observations according to its type and shape.
+
+        :param obs: the batched observation array.
+        :return: the processed observation array of shape (length, obs_dim).
+        """
+        length = obs.shape[0]
+        if self.obs_cls == "discrete":
+            obs = obs.reshape((length, 1))
+            # Return arrays according to one-hot encoding
+            return (obs == np.tile(np.arange(self.obs_dim), (length, 1))).astype(float)
+        elif self.obs_cls == "box":
+            # Flatten all the other
+            return obs.reshape((length, -1))
+        else:
+            raise RuntimeError("Impossible code path.")
+
+    @staticmethod
+    def _act_post_process(act: np.ndarray) -> np.ndarray:
+        """
+        Post-process the actions. Assume actions are discrete with shape (length, 1) or (length).
+
+        :param act: the batched action array.
+        :return: the processed action array of shape (length, 1).
+        """
+        return act.reshape((-1, 1)).astype(int)
+
+    @staticmethod
+    def _rew_post_process(rew: np.ndarray) -> np.ndarray:
+        """
+        Post-process the rewards. Rewards are scalars with shape (length,).
+
+        :param rew: the batched reward array.
+        :return: the processed reward array of shape (length, 1).
+        """
+        return rew.reshape((-1, 1)).astype(float)
+
+    def _get_most_recent_history(
+        self, buffer: ReplayBuffer, length: int, skip: int
+    ) -> tuple:
+        """
+        Get the most recent history from the buffer.
+
+        :param buffer: ReplayBuffer object from stable-baselines3.
+        :param length: the length of steps to sample.
+        :param skip: the amount to skip between states.
+        :return: an (observations, actions, rewards) tuple.
+        """
+        pos = buffer.pos
+        total_length = length * (skip + 1)
+        if pos >= total_length:
+            return (
+                self._obs_post_process(
+                    buffer.observations[pos - total_length : pos : skip + 1]
+                ),
+                self._act_post_process(
+                    buffer.actions[pos - total_length : pos : skip + 1]
+                ),
+                self._rew_post_process(
+                    buffer.rewards[pos - total_length : pos : skip + 1]
+                ),
+            )
+        else:
+            latest = (
+                self._obs_post_process(buffer.observations[: pos : skip + 1]),
+                self._act_post_process(buffer.actions[: pos : skip + 1]),
+                self._rew_post_process(buffer.rewards[: pos : skip + 1]),
+            )
+            if buffer.full:
+                extra = (
+                    self._obs_post_process(
+                        buffer.observations[pos - length :: skip + 1]
+                    ),
+                    self._act_post_process(buffer.actions[pos - length :: skip + 1]),
+                    self._rew_post_process(buffer.rewards[pos - length :: skip + 1]),
+                )
+                latest = tuple(
+                    [np.concatenate([extra[i], latest[i]], axis=0) for i in range(3)]
+                )
+
+            return latest
+
+    def _randomly_sample_buffer(
+        self, buffer: ReplayBuffer, length: int, skip: int
+    ) -> tuple:
+        """
+        Randomly sample a sequence from the buffer (requires that there is enough to sample from).
+
+        :param buffer: ReplayBuffer object from stable-baselines3.
+        :param length: the length of steps to sample.
+        :param skip: the amount to skip between states.
+        :return: an (observations, actions, rewards) tuple.
+        """
+        upper_bound = buffer.size if buffer.full else buffer.pos
+        total_length = length * (skip + 1)
+
+        if total_length > upper_bound:
+            raise IndexError("Buffer contains fewer samples than necessary.")
+
+        start = random.randint(0, upper_bound - total_length)
+        return (
+            self._obs_post_process(
+                buffer.observations[start : start + total_length : skip + 1]
+            ),
+            self._act_post_process(
+                buffer.actions[start : start + total_length : skip + 1]
+            ),
+            self._rew_post_process(
+                buffer.rewards[start : start + total_length : skip + 1]
+            ),
+        )

--- a/algorithm_distillation/task_manager.py
+++ b/algorithm_distillation/task_manager.py
@@ -1,0 +1,45 @@
+import random
+from typing import List
+
+from .task import Task
+
+
+class TaskManager:
+    """
+    This is the controller for a set of tasks (each inherit the `Task` class).
+    Currently, all the methods has trivial behaviors (just pass on to one of the `Task` objects).
+    But I expect more sophisticated behaviors when we move on (also don't forget to remove and update
+    this docstring when we do so!).
+    """
+
+    def __init__(self, tasks: List[Task]):
+        if not tasks:
+            raise ValueError("The task list cannot be empty.")
+        for task in tasks[1:]:
+            if task.obs_dim != tasks[0].obs_dim:
+                raise ValueError("All tasks must have the same obs_dim.")
+
+        self.tasks = tasks
+
+    def train(self, steps: int):
+        """
+        Train `steps` amount of steps for all the tasks.
+
+        :param steps: the amount of gradient steps to train
+        :return: None
+        """
+        for task in self.tasks:
+            task.train(steps)
+
+    def sample_history(self, length: int, skip: int = 0) -> tuple:
+        """
+        Choose a random task and sample a given amount of history.
+        TODO: in the AD paper, it samples sequences for each task and put together as a batch.
+            Here I only sample randomly. Will create another version like the paper's description.
+
+        :param length: length: the length of the history.
+        :param skip: (Optional) skip certain amount of steps between two states.
+        :return: a tuple of (observations, actions, rewards). Each is a tensor.
+        """
+        task = random.choice(self.tasks)
+        return task.sample_history(length, skip=skip)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[tool.isort]
+profile = "black"
+
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+
+[tool.pydocstyle]
+convention = "google"
+add-ignore = "D10"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-rA"
+testpaths = ["tests"]
+
+[project]
+name = "algorithm-distillation"
+description = ""
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "MIT"}
+dynamic = ["version", "dependencies"]
+
+
+[project.optional-dependencies]
+test = [
+    "black",
+    "isort",
+    "flake8",
+    "pydocstyle",
+    "pytype",
+    "pre-commit",
+    "pytest",
+    "pytest-cov",
+]
+notebook = ["ipython"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+stable-baselines3
+transformers~=4.24.0
+torch~=1.12.1
+pytest~=7.2.0
+gym~=0.21.0
+numpy~=1.23.5

--- a/tests/test_ad.py
+++ b/tests/test_ad.py
@@ -1,0 +1,20 @@
+import gym
+
+from algorithm_distillation import GymTask, TaskManager, GymAD
+from algorithm_distillation.models import GPT2AD
+
+
+def test_ad():
+    env = gym.make('FrozenLake-v1')
+    config = {'learning_starts': 10,
+              'buffer_size': 1000,
+              'policy': 'MlpPolicy'
+              }
+    model = GPT2AD(env.observation_space.n, env.action_space.n, 12, max_ep_len=16)
+
+    task = GymTask(env, 'DQN', config)
+    task_manager = TaskManager([task])
+    task_manager.train(100)
+
+    ad = GymAD(model)
+    ad.train(task_manager, 100, 10, skip=0, batch_size=8)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,43 @@
+import gym
+from algorithm_distillation import GymTask
+
+
+def test_gym_task():
+    env = gym.make('FrozenLake-v1')
+    config = {'learning_starts': 10,
+              'buffer_size': 1000,
+              'policy': 'MlpPolicy'
+              }
+    task = GymTask(env, 'DQN', config)
+    assert task.obs_cls == 'discrete'
+    assert task.obs_dim == 16  # The default observation space of FrozenLake is discrete 16 labels
+
+    task.train(100)
+
+    for most_recent in [True, False]:
+        sample = task.sample_history(10, most_recent=most_recent)
+        assert sample[0].shape == (10, 16)  # Observations are discrete classes
+        assert sample[1].shape == (10, 1)  # Actions are discrete classes
+        assert sample[2].shape == (10, 1)  # Rewards.
+
+        sample = task.sample_history(10, skip=2, most_recent=most_recent)
+        assert sample[0].shape == (10, 16)  # Observations are discrete classes
+        assert sample[1].shape == (10, 1)  # Actions are discrete classes
+        assert sample[2].shape == (10, 1)  # Rewards.
+
+    # More than buffer
+    sample = task.sample_history(1000, skip=0, most_recent=True)
+    assert sample[0].shape == (100, 16)  # Observations are discrete classes
+    assert sample[1].shape == (100, 1)  # Actions are discrete classes
+    assert sample[2].shape == (100, 1)  # Rewards.
+
+    """# Please install gym[atari, accept-rom-license] manually if you want to run Atari.
+    env = gym.make('Alien-v4')
+    config = {'learning_starts': 10,
+              'buffer_size': 1000,
+              'policy': 'MlpPolicy'
+              }
+    task = GymTask(env, 'DQN', config)
+    task.train(100)
+    """
+

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,39 @@
+import torch
+import pytest
+from algorithm_distillation.models import GPT2AD
+
+
+@pytest.mark.parametrize("n", [1, 2, 3])
+def test_GPT2AD(n):
+    model = GPT2AD(2, n, 12, max_ep_len=16)
+    model.eval()  # Disable dropout
+    sample_obs = torch.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=torch.float)
+    # two samples, two steps in each trajectory:
+    #   1. [1, 2] -> [3, 4]
+    #   2. [5, 6] -> [7, 8]
+    sample_act = torch.tensor([[[0] * n, [1] * n], [[1] * n, [0] * n]], dtype=torch.float)
+    sample_rew = torch.tensor([[[-1], [1]], [[-1], [0]]], dtype=torch.float)
+    # ... (current: -> [5, 6])
+    # ... (current: -> [9, 10])
+    current_obs = torch.tensor([[5, 6], [9, 10]], dtype=torch.float)
+
+    # Predict the next actions
+    out = model(sample_obs, sample_act, sample_rew, action_only=True)
+    assert out.shape == (2, 2, n)  # 2 observations -> predicting 2 actions
+    out = model(sample_obs, sample_act, sample_rew, current_obs, action_only=True)
+    assert out.shape == (2, 3, n)  # 3 observations -> predicting 3 actions
+    out_act, out_rew, out_obs = model(sample_obs, sample_act, sample_rew, current_obs)
+    assert out_act.shape == (2, 3, n)
+    assert out_rew.shape == (2, 2, 1)
+    assert out_obs.shape == (2, 2, 2)
+
+    # Infer a subsequence and make sure the relevant predictions remain the same.
+    current_obs = sample_obs[:, 1]
+    sample_obs = sample_obs[:, :1]
+    sample_act = sample_act[:, :1]
+    sample_rew = sample_rew[:, :1]
+    new_act, new_rew, new_obs = model(sample_obs, sample_act, sample_rew, current_obs)
+    assert torch.all(new_act.isclose(out_act[:, :-1]))
+    assert torch.all(new_rew.isclose(out_rew[:, :-1]))
+    assert torch.all(new_obs.isclose(out_obs[:, :-1]))
+

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,32 @@
+import torch
+from algorithm_distillation.models.util import stack_seq
+
+
+def test_stack_seq():
+    obs = torch.tensor([[[1, 1], [2, 3]], [[3, 1], [4, 2]]])
+    act = obs + 3
+    rew = obs + 6
+
+    extra = torch.tensor([[[-1, -2], [-3, -4]], [[-5, -6], [-7, -8]]])
+
+    # (obs, act, rew) on the second axis
+    r = torch.tensor([[[1, 1],
+                       [4, 4],
+                       [7, 7],
+                       [2, 3],
+                       [5, 6],
+                       [8, 9],
+                       [-1, -2],
+                       [-3, -4]],
+
+                      [[3, 1],
+                       [6, 4],
+                       [9, 7],
+                       [4, 2],
+                       [7, 5],
+                       [10, 8],
+                       [-5, -6],
+                       [-7, -8]]])
+
+    result = stack_seq(obs, act, rew, extra)
+    assert torch.all(result.isclose(r))


### PR DESCRIPTION
This is to finish the core AD transformer class so that we can build stuff on top of it. The AD transformer is in `algorithm_distillation.models.GPT2AD`.

The code is inspired by [Decision Transformer](https://github.com/kzl/decision-transformer/blob/master/gym/decision_transformer/models/decision_transformer.py). But I personally want to do better than their hacky codes. My biggest complaint is them copy-pasting GPT2 source file and directly change on it (literally wasted the purpose of OOP...).

In DT repo they choose GPT2 as the underlying transformer. I am doing the same here.

## The major extra components for AD/DT comparing with GPT2:
- Instead of token embeddings, we have one layer (linear) for each of observation, action, reward. They all map to the same embedding space. 
(Note: the paper of [multi-game DT](https://arxiv.org/pdf/2205.15241.pdf), they do tokenize obs/act/rew. IMHO the implementation in the original DT repo is enough for our purpose. Specifically, they simply [pre-compose with linear layers](https://github.com/kzl/decision-transformer/blob/e2d82e68f330c00f763507b3b01d774740bee53f/gym/decision_transformer/models/decision_transformer.py#L41) and uses a [trivial vocabulary](https://github.com/kzl/decision-transformer/blob/e2d82e68f330c00f763507b3b01d774740bee53f/gym/decision_transformer/models/decision_transformer.py#L31).)
- The position id (before mapping through positional embedding) is based on the training steps (like `[1, 1, 1, 2, 2, 2, ...]`).  

The rest are relatively minor and obvious (like AD/DT need to stack up in the form of (obs, act, rew, obs, act, rew, ...) sequences, etc.)

## The differences between AD and DT:
- DT is return-conditioned. In the sequence it uses $R^t$ standing for the sum of all future returns (maximized or expected? The paper seems a bit vague on this...). AD uses reward instead.
- multi-game DT predicts return+action+reward. DT and AD papers seem to only care about action predictions (but predicting others may still be possible).

## How to run
This is a skeleton of AD pipeline plus an over-simplified example of single-task AD. The example is in the test `tests/test_ad.py`

Feel free to run the unit tests by
```python
make pytest
```
When it passes through `tests/test_ad.py`, a list of losses will be printed out (during the training of the sequence transformer in Algorithm Distillation for only one-single task of `FrozenLake-v1` environment)

- [x] `GPT2AD` runs, plus a couple very simple unit tests for super basic stuff.
- [x] Defined `Task` abstract class and implemented `GymTask` which manages a gym environment and a stable-baselines3 agent, as well as collects training histories.
- [x] `GymAD` manages AD. `tests/test_ad.py` implements an extremely simple single-task AD (without evaluations yet).